### PR TITLE
Allow either spdx tag or name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 .vscode/
 .pytest_cache/
+*.egg-info/
+build/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In particular, the following things will have to be done:
 - [ ] Evaluate runtime. If scancode-toolkit takes too long on too many cases, we will have to look for an alternative.
 - [x] Allow license name in tag to be also full name of SPDX key.
 - [x] Each LicenseTag should have SPDX id.
+- [ ] Single license tag without file attribute and single license text should match automatically.
 
 ## License
 ros_license_linter is open-sourced under the Apache-2.0 license. See the

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ In particular, the following things will have to be done:
 - [ ] Linter(s) per CI
 - [ ] Field trials (check existing ROS packages and see what to do with the results.)
 - [ ] Evaluate runtime. If scancode-toolkit takes too long on too many cases, we will have to look for an alternative.
-- [ ] Allow license name in tag to be also full name of SPDX key.
-- [ ] Each LicenseTag should have SPDX id.
+- [x] Allow license name in tag to be also full name of SPDX key.
+- [x] Each LicenseTag should have SPDX id.
 
 ## License
 ros_license_linter is open-sourced under the Apache-2.0 license. See the

--- a/src/ros_license_linter/checks.py
+++ b/src/ros_license_linter/checks.py
@@ -19,18 +19,12 @@ import xml.etree.ElementTree as ET
 from pprint import pformat
 from typing import Dict, List, Optional
 
-from spdx.config import LICENSE_MAP
-
-from ros_license_linter.license_tag import LicenseTag
+from ros_license_linter.license_tag import (LicenseTag,
+                                            is_license_name_in_spdx_list)
 from ros_license_linter.package import (Package, PackageException,
                                         get_spdx_license_name,
                                         is_license_text_file)
 from ros_license_linter.ui_elements import NO_REASON_STR, green, red
-
-
-def is_license_name_in_spdx_list(license_name: str) -> bool:
-    """Check if a license name is in the SPDX list of licenses."""
-    return license_name in LICENSE_MAP
 
 
 class Check(object):
@@ -82,7 +76,10 @@ class Check(object):
         try:
             self._check(package)
         except PackageException as e:
-            self._failed(f"Exception: {e}")
+            self._failed(f"PackageException: {e}")
+            return
+        except AssertionError as e:
+            self._failed(f"AssertionError: {e}")
             return
 
     def _check(self, package: Package):

--- a/src/ros_license_linter/checks.py
+++ b/src/ros_license_linter/checks.py
@@ -161,8 +161,8 @@ class LicenseTextExistsCheck(Check):
                 continue
             if actual_license != license_tag.get_license_id():
                 license_tags_without_license_text[license_tag] =\
-                    f"License text file '{license_text_file}' is" +\
-                    "of license {actual_license} but should be" +\
+                    f"License text file '{license_text_file}' is " +\
+                    f"of license {actual_license} but should be" +\
                     f"{license_tag.get_license_id()}."
                 continue
         if len(license_tags_without_license_text) > 0:

--- a/src/ros_license_linter/license_tag.py
+++ b/src/ros_license_linter/license_tag.py
@@ -4,6 +4,24 @@ import xml.etree.ElementTree as ET
 from glob import glob
 from typing import List, Optional
 
+from spdx.config import LICENSE_MAP
+
+
+def is_license_name_in_spdx_list(license_name: str) -> bool:
+    """Check if a license name is in the SPDX list of licenses."""
+    return license_name in LICENSE_MAP.keys() or \
+        license_name in LICENSE_MAP.values()
+
+
+def to_spdx_license_tag(license_name: str) -> str:
+    """Convert a license name to a SPDX license tag."""
+    if license_name in LICENSE_MAP.keys():
+        return license_name
+    if license_name in LICENSE_MAP.values():
+        return list(LICENSE_MAP.keys())[list(LICENSE_MAP.values()).index(
+            license_name)]
+    return license_name
+
 
 class LicenseTag(object):
     """A license tag found in a package.xml file."""
@@ -13,8 +31,11 @@ class LicenseTag(object):
         self.element = element
         assert self.element.text is not None, "License tag must have text."
 
-        # Name of the license (presumably in SPDX format)
-        self.license_id = element.text  # TODO: make sure this is SPDX
+        raw_license_name: str = str(self.element.text)
+        assert is_license_name_in_spdx_list(
+            raw_license_name), "License name must be in SPDX list."
+        # Name of the license (in SPDX tag format for comparability)
+        self.license_id = to_spdx_license_tag(raw_license_name)
 
         # Path to the file containing the license text
         # (relative to package root)

--- a/src/ros_license_linter/license_tag.py
+++ b/src/ros_license_linter/license_tag.py
@@ -29,7 +29,7 @@ def is_license_name_in_spdx_list(license_name: str) -> bool:
 
 
 def to_spdx_license_tag(license_name: str) -> str:
-    """Convert a license name to a SPDX license tag 
+    """Convert a license name to a SPDX license tag
     (assuming it is shorter than the name).
     This is because the dict from spdx.config.LICENSE_MAP
     contains both pairings (tag, name) and (name, tag).

--- a/src/ros_license_linter/license_tag.py
+++ b/src/ros_license_linter/license_tag.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2022 - for information on the respective copyright owner
+# see the NOTICE file and/or the repository
+# https://github.com/boschresearch/ros_license_linter
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import xml.etree.ElementTree as ET
@@ -14,13 +29,18 @@ def is_license_name_in_spdx_list(license_name: str) -> bool:
 
 
 def to_spdx_license_tag(license_name: str) -> str:
-    """Convert a license name to a SPDX license tag."""
-    if license_name in LICENSE_MAP.keys():
-        return license_name
-    if license_name in LICENSE_MAP.values():
-        return list(LICENSE_MAP.keys())[list(LICENSE_MAP.values()).index(
-            license_name)]
-    return license_name
+    """Convert a license name to a SPDX license tag 
+    (assuming it is shorter than the name).
+    This is because the dict from spdx.config.LICENSE_MAP
+    contains both pairings (tag, name) and (name, tag).
+    """
+    for tag, name in LICENSE_MAP.items():
+        if license_name == name or license_name == tag:
+            if len(tag) < len(name):
+                return tag
+            else:
+                return name
+    raise ValueError("License name not in SPDX list.")
 
 
 class LicenseTag(object):

--- a/test/test_all_packages.py
+++ b/test/test_all_packages.py
@@ -36,6 +36,7 @@ class TestAllPackages(unittest.TestCase):
         print(stdout)
         print(stderr)
         self.assertEqual(os.EX_DATAERR, process.returncode)
+        self.assertIn(b"test_pkg_deep", stdout)
         self.assertIn(
             b"test_pkg_has_code_disjoint", stdout)
         self.assertIn(
@@ -47,6 +48,8 @@ class TestAllPackages(unittest.TestCase):
         self.assertIn(b"test_pkg_has_code_of_different_license", stdout)
         self.assertIn(b"test_pkg_no_license_file", stdout)
         self.assertIn(b"test_pkg_no_license", stdout)
+        self.assertIn(b"test_pkg_spdx_name", stdout)
+        self.assertIn(b"test_pkg_spdx_tag", stdout)
         self.assertIn(b"test_pkg_unknown_license", stdout)
         self.assertIn(b"test_pkg_with_license_and_file", stdout)
         self.assertIn(

--- a/test/test_license_per_repo.py
+++ b/test/test_license_per_repo.py
@@ -21,8 +21,6 @@ import unittest
 
 import git
 
-from ros_license_linter.main import main
-
 
 class TestLicensePerRepo(unittest.TestCase):
     """Test that the license per repo is detected correctly.

--- a/test/test_pkg_spdx_name.py
+++ b/test/test_pkg_spdx_name.py
@@ -14,16 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
-from ros_license_linter.checks import is_license_name_in_spdx_list
+from ros_license_linter.main import main
 
 
-class TestChecks(unittest.TestCase):
+class TestPkgSpdxName(unittest.TestCase):
 
-    def test_is_license_name_in_spdx_list(self):
-        self.assertTrue(is_license_name_in_spdx_list("Apache-2.0"))
-        self.assertFalse(is_license_name_in_spdx_list("Apache-2.0-foo"))
+    def test_success(self):
+        self.assertEqual(os.EX_OK, main(
+            ["test/test_pkg_spdx_name"]))
 
 
 if __name__ == '__main__':

--- a/test/test_pkg_spdx_name/LICENSE
+++ b/test/test_pkg_spdx_name/LICENSE
@@ -1,0 +1,46 @@
+The Academic Free License
+ v. 2.0
+
+This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original Work:   
+Licensed under the Academic Free License version 2.0
+
+1) Grant of Copyright License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license to do the following: 
+a) to reproduce the Original Work in copies; 
+
+b) to prepare derivative works ("Derivative Works") based upon the Original Work; 
+
+c) to distribute copies of the Original Work and Derivative Works to the public; 
+
+d) to perform the Original Work publicly; and 
+
+e) to display the Original Work publicly.   
+
+2) Grant of Patent License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and Derivative Works.  
+
+3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work.  Licensor hereby agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes.  Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that information repository in a notice immediately following the copyright notice that applies to the Original Work.    
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior written permission of the Licensor.  Nothing in this License shall be deemed to grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor except as expressly stated herein.  No patent license is granted to make, use, sell or offer to sell embodiments of any patent claims other than the licensed claims defined in Section 2.  No right is granted to the trademarks of Licensor even if such marks are included in the Original Work.  Nothing in this License shall be interpreted to prohibit Licensor from licensing under different terms from this License any Original Work that Licensor otherwise would have a right to license.  
+
+5) This section intentionally omitted.  
+
+6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice."  You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.  
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights.  Except as expressly stated in the immediately proceeding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU.  This DISCLAIMER OF WARRANTY constitutes an essential part of this License.  No license to Original Work is granted hereunder except under this disclaimer.  
+
+8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to any person for any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses.  This limitation of liability shall not apply to liability for death or personal injury resulting from Licensor's negligence to the extent applicable law prohibits such limitation.  Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.  
+
+9) Acceptance and Termination. If You distribute  copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License.  Nothing else but this License (or another written agreement between Licensor and You) grants You permission to create Derivative Works based upon the Original Work or to exercise any of the rights granted in Section 1 herein, and any attempt to do so except under the terms of this License (or another written agreement between Licensor and You) is expressly prohibited by U.S. copyright law, the equivalent laws of other countries, and by international treaty.  Therefore, by exercising any of the rights granted to You in Section 1 herein, You indicate Your acceptance of this License and all of its terms and conditions.    
+
+10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, for patent infringement (i) against Licensor with respect to a patent applicable to software or (ii) against any entity with respect to a patent applicable to the Original Work (but excluding combinations of the Original Work with other software or hardware).    
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions.  The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded.  Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of the U.S. Copyright Act, 17 U.S.C. � 101 et seq., the equivalent laws of other countries, and international treaty.  This section shall survive the termination of this License.  
+
+12) Attorneys Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action.  This section shall survive the termination of this License.  
+
+13) Miscellaneous. This License represents the complete agreement concerning the subject matter hereof.  If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.    
+
+14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License.  For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you.  For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.   
+
+15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.    
+
+This license is Copyright (C) 2003 Lawrence E. Rosen.  All rights reserved.  Permission is hereby granted to copy and distribute this license without modification.  This license may not be modified without the express written permission of its copyright owner. 

--- a/test/test_pkg_spdx_name/package.xml
+++ b/test/test_pkg_spdx_name/package.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_pkg_spdx_name</name>
+  <license file="LICENSE">Academic Free License v2.0</license>
+  <!-- AFL-2.0 -->
+</package>

--- a/test/test_pkg_spdx_tag.py
+++ b/test/test_pkg_spdx_tag.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 - for information on the respective copyright owner
+# see the NOTICE file and/or the repository
+# https://github.com/boschresearch/ros_license_linter
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ros_license_linter.main import main
+
+
+class TestPkgSpdxTag(unittest.TestCase):
+
+    def test_success(self):
+        self.assertEqual(os.EX_OK, main(
+            ["test/test_pkg_spdx_tag"]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_pkg_spdx_tag/LICENSE
+++ b/test/test_pkg_spdx_tag/LICENSE
@@ -1,0 +1,46 @@
+The Academic Free License
+ v. 2.0
+
+This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original Work:   
+Licensed under the Academic Free License version 2.0
+
+1) Grant of Copyright License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license to do the following: 
+a) to reproduce the Original Work in copies; 
+
+b) to prepare derivative works ("Derivative Works") based upon the Original Work; 
+
+c) to distribute copies of the Original Work and Derivative Works to the public; 
+
+d) to perform the Original Work publicly; and 
+
+e) to display the Original Work publicly.   
+
+2) Grant of Patent License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and Derivative Works.  
+
+3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work.  Licensor hereby agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes.  Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that information repository in a notice immediately following the copyright notice that applies to the Original Work.    
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior written permission of the Licensor.  Nothing in this License shall be deemed to grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor except as expressly stated herein.  No patent license is granted to make, use, sell or offer to sell embodiments of any patent claims other than the licensed claims defined in Section 2.  No right is granted to the trademarks of Licensor even if such marks are included in the Original Work.  Nothing in this License shall be interpreted to prohibit Licensor from licensing under different terms from this License any Original Work that Licensor otherwise would have a right to license.  
+
+5) This section intentionally omitted.  
+
+6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice."  You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.  
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights.  Except as expressly stated in the immediately proceeding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU.  This DISCLAIMER OF WARRANTY constitutes an essential part of this License.  No license to Original Work is granted hereunder except under this disclaimer.  
+
+8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to any person for any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses.  This limitation of liability shall not apply to liability for death or personal injury resulting from Licensor's negligence to the extent applicable law prohibits such limitation.  Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.  
+
+9) Acceptance and Termination. If You distribute  copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License.  Nothing else but this License (or another written agreement between Licensor and You) grants You permission to create Derivative Works based upon the Original Work or to exercise any of the rights granted in Section 1 herein, and any attempt to do so except under the terms of this License (or another written agreement between Licensor and You) is expressly prohibited by U.S. copyright law, the equivalent laws of other countries, and by international treaty.  Therefore, by exercising any of the rights granted to You in Section 1 herein, You indicate Your acceptance of this License and all of its terms and conditions.    
+
+10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, for patent infringement (i) against Licensor with respect to a patent applicable to software or (ii) against any entity with respect to a patent applicable to the Original Work (but excluding combinations of the Original Work with other software or hardware).    
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions.  The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded.  Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of the U.S. Copyright Act, 17 U.S.C. � 101 et seq., the equivalent laws of other countries, and international treaty.  This section shall survive the termination of this License.  
+
+12) Attorneys Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action.  This section shall survive the termination of this License.  
+
+13) Miscellaneous. This License represents the complete agreement concerning the subject matter hereof.  If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.    
+
+14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License.  For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you.  For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.   
+
+15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.    
+
+This license is Copyright (C) 2003 Lawrence E. Rosen.  All rights reserved.  Permission is hereby granted to copy and distribute this license without modification.  This license may not be modified without the express written permission of its copyright owner. 

--- a/test/test_pkg_spdx_tag/package.xml
+++ b/test/test_pkg_spdx_tag/package.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_pkg_spdx_tag</name>
+  <license file="LICENSE">AFL-2.0</license>
+  <!-- Academic Free License v2.0 -->
+</package>

--- a/test/test_unittest_license_tag.py
+++ b/test/test_unittest_license_tag.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 - for information on the respective copyright owner
+# see the NOTICE file and/or the repository
+# https://github.com/boschresearch/ros_license_linter
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from xml.etree import ElementTree as ET
+
+from ros_license_linter.license_tag import (LicenseTag,
+                                            is_license_name_in_spdx_list)
+
+
+class TestChecks(unittest.TestCase):
+
+    def test_is_license_name_in_spdx_list(self):
+        self.assertTrue(is_license_name_in_spdx_list("Apache-2.0"))
+        self.assertFalse(is_license_name_in_spdx_list("Apache-2.0-foo"))
+
+    def test_init(self):
+        by_spdx_tag = LicenseTag(ET.fromstring(
+            "<license>Apache-2.0</license>"), "")
+        self.assertEqual(by_spdx_tag.license_id, "Apache-2.0")
+        by_spdx_name = LicenseTag(ET.fromstring(
+            "<license>Apache License 2.0</license>"), "")
+        self.assertEqual(by_spdx_name.license_id, "Apache-2.0")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
the license tag in the package.xml can be for example either `<license>Apache-2.0</license>` or `<license>Apache License 2.0</license>`.